### PR TITLE
Create Dockerfile for the tnfs-php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:8-apache
+
+RUN docker-php-ext-install sockets
+
+COPY tnfs-php-example/ /var/www/html/
+COPY tnfs.php /var/www/html/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 This is a class for using the [TNFS protocol](https://github.com/FujiNetWIFI/spectranet/blob/master/tnfs/tnfs-protocol.md) with PHP. An example script is included.
 
+## Docker
+
+To run the example script with Docker, please execute:
+
+```
+docker build -t tnfs .
+docker run -ti --rm -p 80:8080 tnfs
+```
+
+And then open http://localhost:8080 in your browser.

--- a/tnfs-php-example/index.php
+++ b/tnfs-php-example/index.php
@@ -444,13 +444,6 @@ error_reporting(E_ERROR | E_PARSE);
 
 	}
 
-function cmp($a, $b)
-{
-    return strcmp($a->name, $b->name);
-}
-
-usort($your_data, "cmp");
-
 ?>
 
 <!doctype html>

--- a/tnfs.php
+++ b/tnfs.php
@@ -195,6 +195,17 @@ class TNFS{
         }
     }
 
+    public function __sleep(){
+        return array('DEBUG', 'CONNECTION_ID', 'BUFFER', 'CONNECTED', 'SERVER_IP', 'SERVER_PORT', 'SEQUENCE');    
+    }
+
+    public function __wakeup(){
+        $this->createSocket();
+        if($this->socket == null){
+            $this->CONNECTED = false;
+        }
+    }
+
     // -----------------------------------------------------------------
     // DEVICE
     


### PR DESCRIPTION
With Dockerfile, the sample PHP client for TNFS can be build and started with just 2 commands. The PR includes 2 other minor fixes - without them, the script doesn't work correctly or displays warnings.