### PR TITLE
More resilient response parsing.

### DIFF
--- a/tnfs-php-example/config.php
+++ b/tnfs-php-example/config.php
@@ -1,0 +1,17 @@
+<?php
+define('TNFS_HOSTS', array(
+    '192.168.1.61',
+    'irata.online',
+    'zxnet.co.uk',
+    'tnfs.bytedelight.com',
+    'vexed4.alioth.net',
+    'zx.kupo.be',
+    'nihirash.net',
+    'tnfs.millhill.org',
+    'fujinet.online',
+    'tnfs.atari8bit.net',
+    'atari-apps.irata.online',
+    'homesoft.irata.online',
+    'fujinet.pl'
+));
+?>

--- a/tnfs-php-example/index.php
+++ b/tnfs-php-example/index.php
@@ -115,7 +115,7 @@ error_reporting(E_ERROR | E_PARSE);
 						do{
 						    $read = $tnfs->readdir($directory["Handle"]);
 						    
-						    if($read["Code"] != TNFS::$RET_EOF){
+						    if($read["Code"] == TNFS::$RET_SUCCESS){
 						        if($read["Filename"] == "." || $read["Filename"] == ".."){
 						            continue;
 						        }
@@ -137,7 +137,7 @@ error_reporting(E_ERROR | E_PARSE);
 						    		$filelist[] = $read;
 						    }
 						    
-						} while($read["Code"] != TNFS::$RET_EOF);
+						} while($read["Code"] == TNFS::$RET_SUCCESS);
 						$tnfs->closedir($directory["Handle"]);
 
 						

--- a/tnfs-php-example/index.php
+++ b/tnfs-php-example/index.php
@@ -4,6 +4,7 @@ error_reporting(E_ERROR | E_PARSE);
 
 
 	include("tnfs.php");
+	include("config.php");
 	session_start();
 
 	function startsWith( $haystack, $needle ) {
@@ -371,23 +372,13 @@ error_reporting(E_ERROR | E_PARSE);
 
 		if($tnfs != null && isset($_REQUEST["disconnect"])){
 			if($tnfs != null){
-				//echo "DESCO";
-				//$disconnect = true;
 				$tnfs->umount();
 				$tnfs->destroy();
 				unset($_SESSION["sid"]);
 				session_unset();
 				session_destroy();
 				$tnfs->CONNECTED == false;
-				//$tnfs = null;
 				$sid = 0;
-				$connected = false;
-				$host = "192.168.1.61";
-				$port = 16384;
-				$protocol = "tcp";
-			} else {
-			//	$host = "192.168.1.33";
-			//	$port = 16384;
 			}
 		} 
 
@@ -400,10 +391,9 @@ error_reporting(E_ERROR | E_PARSE);
 		$connected = true;
 	} else {
 		$connected = false;
-		$host = "192.168.1.61";
+		$host = TNFS_HOSTS[0];
 		$port = 16384;
 		$protocol = "tcp";
-
 	}
 
 ?>
@@ -946,21 +936,9 @@ error_reporting(E_ERROR | E_PARSE);
 								  <div id="dropdown-hosts-list" style="margin-top:-8px" class="form-control dropdown-menu" aria-labelledby="dropdown-hosts">
 								    <input autocomplete="off" style="height:auto;" type="text" <?php if($tnfs != null && $tnfs->CONNECTED == true) echo " disabled ";?> class="form-control mr-sm-2" value="<?php echo $host;?>" name="host" id="host" placeholder="tnfs host">                                  																		    
 								    <span href="#" style="background-color:#fff; padding:5px 0px" class="dropdown-item"><hr style="margin:0;border-top:2px solid #000"/></span>
-
-								    <a class="dropdown-item host-element" href="#">192.168.1.61</a>
-								    <a class="dropdown-item host-element" href="#">irata.online</a>
-								    <a class="dropdown-item host-element" href="#">zxnet.co.uk</a>
-									<a class="dropdown-item host-element" href="#">tnfs.bytedelight.com</a>								    
-								    <a class="dropdown-item host-element" href="#">vexed4.alioth.net</a>								    
-								    <a class="dropdown-item host-element" href="#">zx.kupo.be</a>	
-								    <a class="dropdown-item host-element" href="#">nihirash.net</a>									    
-								    <a class="dropdown-item host-element" href="#">tnfs.millhill.org</a>									    								    
-
-								    <a class="dropdown-item host-element" href="#">fujinet.online</a>									    								    
-								    <a class="dropdown-item host-element" href="#">tnfs.atari8bit.net</a>									    								    
-								    <a class="dropdown-item host-element" href="#">atari-apps.irata.online</a>									    								    
-								    <a class="dropdown-item host-element" href="#">homesoft.irata.online</a>									    								    
-								    <a class="dropdown-item host-element" href="#">fujinet.pl</a>									    								    
+									<?php foreach(TNFS_HOSTS as $host): ?>
+										<a class="dropdown-item host-element" href="#"><?php echo $host ?></a>
+									<?php endforeach ?>
 								  </div>
 								</div>
 							</div>

--- a/tnfs.php
+++ b/tnfs.php
@@ -759,8 +759,7 @@ class TNFS{
         $pos = 0;
         do {
             $res = $this->read($handle, TNFS::$READ_BLOCK_SIZE);
-            //var_dump($res);
-            if($res["Code"] != TNFS::$RET_EOF){
+            if($res["Code"] == TNFS::$RET_SUCCESS){
                 $file_content .= $res["Content"];
                 $pos = $pos + $res["Length"];
                 if($pos < $filesize){
@@ -769,7 +768,7 @@ class TNFS{
                     break;
                 }
             }
-        } while($res["Code"] != TNFS::$RET_EOF);
+        } while($res["Code"] == TNFS::$RET_SUCCESS);
 
         return $file_content;
     }


### PR DESCRIPTION
This PR introduces more resilient response parsing, in case it returns error rather than output defined in the optional `$format` parameter. With this improvement, we can use `stat('ping')` operation to check if the session is valid (`free()` operation logs an error in the tnfsd).

Apart from that, the host list has been extracted to a separate file.